### PR TITLE
Set Grub Setting for 3.2 Update

### DIFF
--- a/helper_scripts/config_switch.sh
+++ b/helper_scripts/config_switch.sh
@@ -42,6 +42,8 @@ sed -i 's/bgpd=no/bgpd=yes/g' /etc/quagga/daemons
 systemctl enable quagga.service
 systemctl start quagga.service
 
+echo grub-pc grub-pc/install_devices select /dev/sda | sudo debconf-set-selections
+
 #Upgrading Quagga for EVPN
 sed -i 's/#deb     http:\/\/repo3.cumulusnetworks.com\/repo CumulusLinux-3-early-access cumulus/deb     http:\/\/repo3.cumulusnetworks.com\/repo CumulusLinux-3-early-access cumulus/' /etc/apt/sources.list
 sed -i 's/#deb-src http:\/\/repo3.cumulusnetworks.com\/repo CumulusLinux-3-early-access cumulus/deb-src http:\/\/repo3.cumulusnetworks.com\/repo CumulusLinux-3-early-access cumulus/' /etc/apt/sources.list


### PR DESCRIPTION
The Vagrantfile is based on 3.1 and the switch runs apt-get upgrade, moving it to 3.2 Virtualbox editions of Vx do not support non-interactive upgrades due to CM-12631. This sets the flag before upgrade to answer the grub prompt.